### PR TITLE
Require Keys to be usable as Irmin paths.

### DIFF
--- a/lib/inds_entry.ml
+++ b/lib/inds_entry.ml
@@ -5,27 +5,25 @@ module Make(Entry: Inds_types.ENTRY_ELIGIBLE) = struct
   type t = 
     | Confirmed of int * Entry.t
 
-  let make_confirmed time mac = Confirmed (time, mac)
-
-  let to_string = function
-    | Confirmed (time, mac) -> Printf.sprintf "%s expiring at %d"
-                                 (Entry.to_string mac) time
+  let make_confirmed time entry = Confirmed (time, entry)
 
   let to_json = function
-    | Confirmed (time, mac) -> 
+    | Confirmed (time, entry) -> 
       let expiry = Ezjsonm.int time in
-      let mac = Ezjsonm.string (Entry.to_string mac) in
-      Ezjsonm.dict [("expiry", expiry); ("mac", mac)]
+      let entry = Ezjsonm.string (Entry.to_string entry) in
+      Ezjsonm.dict [("expiry", expiry); ("entry", entry)]
 
-  let of_json (json : Ezjsonm.value) : t option = match json with
-    | `A _ | `Null | `Bool _ | `Float _ | `String _ -> None
+  let of_json (json : Ezjsonm.value) = match json with
+    | `A _ | `Null | `Bool _ | `Float _ | `String _ ->
+      raise (Invalid_argument "entry.of_json expects a dictionary,
+      but was given some other json")
     | `O items ->
         let open Ezjsonm in
-          match (Entry.of_string (get_string (find (dict items) ["mac"]))) with
-          | None -> None
+          match (Entry.of_string (get_string (find (dict items) ["entry"]))) with
+          | None -> raise (Invalid_argument "parse failure in an entry")
           | Some address -> (
             let expiry = get_int (find (dict items) ["expiry"]) in
-            Some (Confirmed (expiry, address)) )
+            Confirmed (expiry, address))
 
   let compare p q =
     match (p, q) with

--- a/lib/inds_key.ml
+++ b/lib/inds_key.ml
@@ -1,10 +1,6 @@
 (* provide Tc.S0 stuff for Key *)
 module Make(Key : Inds_types.KEY_ELIGIBLE) = struct
-  type t = Key.t
-
-  let compare = Key.compare
-  let of_string = Key.of_string
-  let to_string = Key.to_string
+  include Key
 
   let read buf =
     let raw = Mstruct.to_string buf in

--- a/lib/inds_table.ml
+++ b/lib/inds_table.ml
@@ -15,7 +15,7 @@ module Make (Key: Inds_types.KEY) (Entry: Inds_types.ENTRY) (P: Irmin.Path.S) = 
       in
       let mapify map (name, entry) = 
         match (Key.of_string name), entry with 
-        | Some key, Some entry -> M.add key entry map
+        | Some key, entry -> M.add key entry map
         | _, _ -> map
       in
       List.fold_left mapify M.empty entries
@@ -26,8 +26,7 @@ module Make (Key: Inds_types.KEY) (Entry: Inds_types.ENTRY) (P: Irmin.Path.S) = 
           Ezjsonm.update json [(Key.to_string key)] (Some (Entry.to_json value) )
         with
         | Not_found ->
-          raise (Invalid_argument (Printf.sprintf "Couldn't make json out of key %s and entry %s" 
-                                     (Key.to_string key) (Entry.to_string value)))
+          raise (Invalid_argument "failure constructing JSON")
       in
       M.fold add_binding map (Ezjsonm.dict [])
 

--- a/lib/inds_types.mli
+++ b/lib/inds_types.mli
@@ -13,10 +13,9 @@ module type ENTRY = sig
   type entry
   type t = | Confirmed of int * entry
   type result = [ `Ok of entry | `Timeout ]
-  val of_json : Ezjsonm.value -> t option
+  val of_json : Ezjsonm.value -> t
   val to_json : t -> Ezjsonm.value
   val compare : t -> t -> int
-  val to_string : t -> string
   val make_confirmed : int -> entry -> t
 end
 
@@ -30,7 +29,4 @@ module type KEY = sig
   include KEY_ELIGIBLE with type t := t
   val to_json : t -> Ezjsonm.value
   val of_json : Ezjsonm.value -> t
-  val read : t Tc.reader
-  val write : t Tc.writer
-  val size_of : t -> int
 end

--- a/lib/inds_types.mli
+++ b/lib/inds_types.mli
@@ -28,4 +28,9 @@ end
 module type KEY = sig
   include Map.OrderedType
   include KEY_ELIGIBLE with type t := t
+  val to_json : t -> Ezjsonm.value
+  val of_json : Ezjsonm.value -> t
+  val read : t Tc.reader
+  val write : t Tc.writer
+  val size_of : t -> int
 end

--- a/lib/inds_wrappers.ml
+++ b/lib/inds_wrappers.ml
@@ -9,7 +9,15 @@ end
 
 module Ipv4addr_key : sig
   include Inds_types.KEY_ELIGIBLE with type t = Ipaddr.V4.t
+  val of_json : Ezjsonm.value -> t
+  val to_json : t -> Ezjsonm.value
 end = struct
   include Ipaddr.V4
   let size_of addr = Ipaddr.V4.to_string addr |> String.length
+  let of_json = function
+    | `String s -> Ipaddr.V4.of_string_exn s
+    | _ -> raise (Invalid_argument "invalid json presented to ipv4")
+
+  let to_json t =
+    Ezjsonm.from_string (Ipaddr.V4.to_string t)
 end

--- a/lib/inds_wrappers.ml
+++ b/lib/inds_wrappers.ml
@@ -6,3 +6,10 @@ end = struct
   let to_string = Macaddr.to_string ~sep:':' (* a lot of work for a sep:':'! *)
   let of_string = Macaddr.of_string
 end
+
+module Ipv4addr_key : sig
+  include Inds_types.KEY_ELIGIBLE with type t = Ipaddr.V4.t
+end = struct
+  include Ipaddr.V4
+  let size_of addr = Ipaddr.V4.to_string addr |> String.length
+end

--- a/lib_test/test_lib.ml
+++ b/lib_test/test_lib.ml
@@ -1,5 +1,5 @@
 module Entry = Inds_entry.Make(Inds_wrappers.Macaddr_entry)
-module Key = Inds_key.Make(Ipaddr.V4)
+module Key = Inds_key.Make(Inds_wrappers.Ipv4addr_key)
 module T = Inds_table.Make(Key)(Entry)(Irmin.Path.String_list)
 module Ipv4_map = T.M
 

--- a/lib_test/test_lib.ml
+++ b/lib_test/test_lib.ml
@@ -25,7 +25,7 @@ let assert_in m k =
     ~printer:string_of_bool true (Ipv4_map.mem k m)
 let assert_resolves m k v =
   assert_in m k;
-  OUnit.assert_equal ~printer:Entry.to_string v (Ipv4_map.find k m)
+  OUnit.assert_equal v (Ipv4_map.find k m)
 let assert_absent m k =
   OUnit.assert_equal ~msg:"asserting absence of key fails" 
     ~printer:string_of_bool false (Ipv4_map.mem k m)

--- a/lib_test/test_ops.ml
+++ b/lib_test/test_ops.ml
@@ -6,12 +6,12 @@ let write_empty_json () =
   OUnit.assert_equal ~printer:(fun p -> Ezjsonm.to_string (Ezjsonm.wrap p)) 
     (Ezjsonm.dict []) (T.to_json map)
 
-let write_single_complete_entry () =
+let write_singleton_map () =
   let map = Ipv4_map.empty in
   (* one entry -> dictionary json entry *)
   let populated_map = Ipv4_map.add ip1 (confirm time1 mac1) map in
   let populated_json = T.Ops.to_json populated_map in
-  Printf.printf "%s\n" (Ezjsonm.to_string (Ezjsonm.wrap populated_json));
+  Printf.printf "result of to_json: %s\n" (Ezjsonm.to_string (Ezjsonm.wrap populated_json));
   let dict = Ezjsonm.get_dict populated_json in
   (* there's one (and only one) entry *)
   OUnit.assert_equal ~printer:string_of_int 1 (List.length dict); 
@@ -21,12 +21,11 @@ let write_single_complete_entry () =
   let ip1_node = Ezjsonm.find populated_json [ip1_str] in
   (* both expiry and mac are present *)
   OUnit.assert_equal ~printer:string_of_bool true (Ezjsonm.mem ip1_node ["expiry"]);
-  OUnit.assert_equal ~printer:string_of_bool true (Ezjsonm.mem ip1_node ["mac"]);
+  OUnit.assert_equal ~printer:string_of_bool true (Ezjsonm.mem ip1_node ["entry"]);
   (* and their entries are correct *)
   OUnit.assert_equal ~printer:string_of_int time1 (Ezjsonm.get_int (Ezjsonm.find ip1_node ["expiry"]));
   OUnit.assert_equal mac1_str (Ezjsonm.get_string (Ezjsonm.find ip1_node
-                                                     ["mac"]));
-  (* { "192.168.3.50":{ "expiry":0.0, "mac":"00:11:22:33:44:55" } } *)
+                                                     ["entry"]));
   ()
 
 let write_populated_map () = 
@@ -39,7 +38,7 @@ let write_populated_map () =
   OUnit.assert_equal true (Ezjsonm.mem json [ip2_str])
 
 let valify mac time = 
-  Ezjsonm.dict [ ("mac", (Ezjsonm.string mac));
+  Ezjsonm.dict [ ("entry", (Ezjsonm.string mac));
                  ("expiry", (Ezjsonm.int time)) ]
 
 let formulate_json name mac time =
@@ -123,7 +122,7 @@ let () =
   ] in
   let json = [ 
     "write_empty_map", `Slow, write_empty_json;
-    "write_singleton_map", `Slow, write_single_complete_entry;
+    "write_singleton_map", `Slow, write_singleton_map;
     "write_populated_map", `Slow, write_populated_map;
     "read_empty_map", `Slow, read_empty_json;
     "read_singleton_map", `Slow, read_singleton_map;


### PR DESCRIPTION
Users of irmin-network-datastores are likely to wish to store keys and values directly in the store, rather than through a Map intermediary.  To support this, require that Keys provide enough information to construct the required functions to fulfill the Irmin.Path.S module type.